### PR TITLE
Hide empty status texts

### DIFF
--- a/wa_purple.c
+++ b/wa_purple.c
@@ -132,10 +132,14 @@ static void waprpl_tooltip_text(PurpleBuddy *buddy, PurpleNotifyUserInfo *info, 
 }
 
 static char *waprpl_status_text(PurpleBuddy *buddy) {
+  char * statusmsg;
   whatsapp_connection * wconn = purple_connection_get_protocol_data(purple_account_get_connection(purple_buddy_get_account(buddy)));
   if (!wconn) return 0;
 
-  return waAPI_getuserstatusstring(wconn->waAPI,purple_buddy_get_name(buddy));
+  statusmsg = waAPI_getuserstatusstring(wconn->waAPI, purple_buddy_get_name(buddy));
+  if (!statusmsg || strlen(statusmsg) == 0)
+    return NULL;
+  return statusmsg;
 }
 
 static const char *waprpl_list_icon(PurpleAccount *acct, PurpleBuddy *buddy) {


### PR DESCRIPTION
It seems like WhatsApp advertises an empty string if one doesn't set a
status text explicitly. This leads to strange formatting of buddies in
Pidgin's buddy list when buddy details are enabled. Prevent this by
pretending a NULL status text if the status message is empty.

Signed-off-by: Lukas Fleischer info@cryptocrack.de
