### PR TITLE
Add offline status

### DIFF
--- a/wa_purple.c
+++ b/wa_purple.c
@@ -752,6 +752,9 @@ static GList *waprpl_status_types(PurpleAccount *acct) {
       "message", "Message", purple_value_new(PURPLE_TYPE_STRING), NULL);
   types = g_list_prepend(types, type);
 
+  type = purple_status_type_new(PURPLE_STATUS_OFFLINE, NULL, NULL, TRUE);
+  types = g_list_append(types, type);
+
   return g_list_reverse(types);
 }
 


### PR DESCRIPTION
Register the offline status to make sure waprpl_close() actually gets
called when the user decides to go offline. Fixes #8.

Signed-off-by: Lukas Fleischer info@cryptocrack.de
