### PR TITLE
Added missing wa_util.cc to Makefile.mingw CXX_SRCS for Windows compiling

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -4,7 +4,7 @@ LIBNAME = libwhatsapp.dll
 all: $(LIBNAME)
 
 C_SRCS = wa_purple.c tinfl.c imgutil.c
-CXX_SRCS = whatsapp-protocol.cc wa_api.cc rc4.cc keygen.cc tree.cc databuffer.cc message.cc whatsapp_api.cc
+CXX_SRCS = whatsapp-protocol.cc wa_api.cc wa_util.cc rc4.cc keygen.cc tree.cc databuffer.cc message.cc whatsapp_api.cc
 
 C_OBJS = $(C_SRCS:.c=.o)
 CXX_OBJS = $(CXX_SRCS:.cc=.o)


### PR DESCRIPTION
Makefile.mingw needed to be updated so that it compiles, given the latest addition of 'wa_util.cc'.