### PR TITLE
Added information on requirements for building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ Official binary sources (provided by davidgfnet):
 Building
 --------
 
+Next to the `build-essentials`, you will need `protobuf-compiler` and the 
+following headers `libpurple-dev`, `libprotobuf-dev`, `libfreeimage-dev`.
+
 Just run `make` (if you have to choose between 32 and 64 bit, run `make
 ARCH=i686` or `make ARCH=x86_64`). `Makefile.mingw` is the Makefile for 32-bit
-Windows.
+Windows. 
 
 FAQ
 ---


### PR DESCRIPTION
Hi @davidgfnet , great plugin. I had to build on Debian Jessie (ppa approach didn't work). I did have build-essential on my system, but was missing quite a few libraries. I took note of them and added this to the readme. Hopefully it can help others and you find this useful.
